### PR TITLE
Remove explicit kitchen-vagrant requirement

### DIFF
--- a/local_chef_dev_setup.md
+++ b/local_chef_dev_setup.md
@@ -23,9 +23,6 @@
 
 `which bundle && bundle -v`
 
-### Install kitchen-vagrant gem if not already present
-`chef gem install kitchen-vagrant`
-
 ## Local cookbook development workflow
 
 ### create new cookbook using Berkshelf


### PR DESCRIPTION
It's part of `chef-dk`
